### PR TITLE
RSS guids are marked isPermaLink=false

### DIFF
--- a/feedgenerator/django/utils/feedgenerator.py
+++ b/feedgenerator/django/utils/feedgenerator.py
@@ -279,7 +279,7 @@ class Rss201rev2Feed(RssFeed):
         if item['comments'] is not None:
             handler.addQuickElement("comments", item['comments'])
         if item['unique_id'] is not None:
-            handler.addQuickElement("guid", item['unique_id'])
+            handler.addQuickElement("guid", item['unique_id'], attrs={'isPermaLink': 'false'})
         if item['ttl'] is not None:
             handler.addQuickElement("ttl", item['ttl'])
 


### PR DESCRIPTION
In my present understanding, RSS feeds generated by feedgenerator.Rss201rev2Feed use tag-formatted guids rather than permanent links. These feeds fail W3C RSS validation because the tag uris aren't valid permalinks.

To mitigate this, this patch sets isPermaLink=false for guid tags generated from the Rss201rev2Feed object.