### PR TITLE
Fix support for a couple Atom features

### DIFF
--- a/feedgenerator/django/utils/feedgenerator.py
+++ b/feedgenerator/django/utils/feedgenerator.py
@@ -114,11 +114,11 @@ class SyndicationFeed(object):
     def add_item(self, title, link, description, author_email=None,
         author_name=None, author_link=None, pubdate=None, comments=None,
         unique_id=None, enclosure=None, categories=(), item_copyright=None,
-        ttl=None, content=None, **kwargs):
+        ttl=None, content=None, updateddate=None, **kwargs):
         """
         Adds an item to the feed. All args are expected to be Python Unicode
-        objects except pubdate, which is a datetime.datetime object, and
-        enclosure, which is an instance of the Enclosure class.
+        objects except pubdate and updateddate, which are datetime.datetime
+        objects, and enclosure, which is an instance of the Enclosure class.
         """
         to_unicode = lambda s: force_text(s, strings_only=True)
         if categories:
@@ -135,6 +135,7 @@ class SyndicationFeed(object):
             'author_name': to_unicode(author_name),
             'author_link': iri_to_uri(author_link),
             'pubdate': pubdate,
+            'updateddate': updateddate,
             'comments': to_unicode(comments),
             'unique_id': to_unicode(unique_id),
             'enclosure': enclosure,
@@ -191,10 +192,11 @@ class SyndicationFeed(object):
 
     def latest_post_date(self):
         """
-        Returns the latest item's pubdate. If none of them have a pubdate,
-        this returns the current date/time.
+        Returns the latest item's pubdate or updateddate. If no item has either
+        date, returns the current date/time.
         """
         updates = [i['pubdate'] for i in self.items if i['pubdate'] is not None]
+        updates.extend(i['updateddate'] for i in self.items if i['updateddate'] is not None)
         if len(updates) > 0:
             updates.sort()
             return updates[-1]
@@ -346,6 +348,8 @@ class Atom1Feed(SyndicationFeed):
         handler.addQuickElement("link", "", {"href": item['link'], "rel": "alternate"})
         if item['pubdate'] is not None:
             handler.addQuickElement("published", rfc3339_date(item['pubdate']))
+        if item['updateddate'] is not None:
+            handler.addQuickElement("updated", rfc3339_date(item['updateddate']))
 
         # Author information.
         if item['author_name'] is not None:

--- a/feedgenerator/django/utils/feedgenerator.py
+++ b/feedgenerator/django/utils/feedgenerator.py
@@ -114,7 +114,7 @@ class SyndicationFeed(object):
     def add_item(self, title, link, description, author_email=None,
         author_name=None, author_link=None, pubdate=None, comments=None,
         unique_id=None, enclosure=None, categories=(), item_copyright=None,
-        ttl=None, **kwargs):
+        ttl=None, content=None, **kwargs):
         """
         Adds an item to the feed. All args are expected to be Python Unicode
         objects except pubdate, which is a datetime.datetime object, and
@@ -130,6 +130,7 @@ class SyndicationFeed(object):
             'title': to_unicode(title),
             'link': iri_to_uri(link),
             'description': to_unicode(description),
+            'content': to_unicode(content),
             'author_email': to_unicode(author_email),
             'author_name': to_unicode(author_name),
             'author_link': iri_to_uri(author_link),
@@ -366,6 +367,10 @@ class Atom1Feed(SyndicationFeed):
         # Summary.
         if item['description'] is not None:
             handler.addQuickElement("summary", item['description'], {"type": "html"})
+
+        # Full content.
+        if item['content'] is not None:
+            handler.addQuickElement("content", item['content'], {"type": "html"})
 
         # Enclosure.
         if item['enclosure'] is not None:

--- a/feedgenerator/django/utils/feedgenerator.py
+++ b/feedgenerator/django/utils/feedgenerator.py
@@ -345,7 +345,7 @@ class Atom1Feed(SyndicationFeed):
         handler.addQuickElement("title", item['title'])
         handler.addQuickElement("link", "", {"href": item['link'], "rel": "alternate"})
         if item['pubdate'] is not None:
-            handler.addQuickElement("updated", rfc3339_date(item['pubdate']))
+            handler.addQuickElement("published", rfc3339_date(item['pubdate']))
 
         # Author information.
         if item['author_name'] is not None:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ PACKAGES = ['feedgenerator', 'feedgenerator.django',
 DESCRIPTION = 'Standalone version of django.utils.feedgenerator, compatible with Py3k'
 LONG_DESCRIPTION = open('README.rst').read()
 
-URL = "https://github.com/dmdm/feedgenerator-py3k.git"
+URL = "https://github.com/getpelican/feedgenerator"
 
 CLASSIFIERS = ['Development Status :: 3 - Alpha',
                'Environment :: Web Environment',

--- a/tests_feedgenerator/test_feedgenerator.py
+++ b/tests_feedgenerator/test_feedgenerator.py
@@ -24,7 +24,8 @@ FIXT_FEED = dict(
 FIXT_ITEM = dict(
     title="Hello",
     link="http://www.holovaty.com/test/",
-    description="Testing."
+    description="Testing.",
+    content="Full content of our testing entry.",
 )
 
 
@@ -36,7 +37,7 @@ EXPECTED_RESULT_RSS = """<?xml version="1.0" encoding="utf-8"?>
     </description><language>en</language><lastBuildDate>%DATE%</lastBuildDate><item><title>Hello</title><link>http://www.holovaty.com/test/</link><description>Testing.</description></item></channel></rss>"""
 
 EXPECTED_RESULT_ATOM = """<?xml version="1.0" encoding="utf-8"?>
-<feed xml:lang="en" xmlns="http://www.w3.org/2005/Atom"><title>Poynter E-Media Tidbits</title><link href="http://www.poynter.org/column.asp?id=31" rel="alternate"></link><id>http://www.poynter.org/column.asp?id=31</id><updated>%DATE%</updated><entry><title>Hello</title><link href="http://www.holovaty.com/test/" rel="alternate"></link><id>tag:www.holovaty.com:/test//</id><summary type="html">Testing.</summary></entry></feed>"""
+<feed xml:lang="en" xmlns="http://www.w3.org/2005/Atom"><title>Poynter E-Media Tidbits</title><link href="http://www.poynter.org/column.asp?id=31" rel="alternate"></link><id>http://www.poynter.org/column.asp?id=31</id><updated>%DATE%</updated><entry><title>Hello</title><link href="http://www.holovaty.com/test/" rel="alternate"></link><id>tag:www.holovaty.com:/test//</id><summary type="html">Testing.</summary><content type="html">Full content of our testing entry.</content></entry></feed>"""
 
 ENCODING = 'utf-8'
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py32,py33
+envlist = py26,py27,py32,py33,py34,py35
 
 [testenv]
 commands = unit2 discover
@@ -17,5 +17,13 @@ deps =
 	unittest2py3k
 
 [testenv:py33]
+deps =
+	unittest2py3k
+
+[testenv:py34]
+deps =
+	unittest2py3k
+
+[testenv:py35]
 deps =
 	unittest2py3k


### PR DESCRIPTION
`<content>` was unsupported, and the published date was incorrectly being added as `<updated>` rather than `<published>`.

Also added the last couple 3.x releases to tox, and updated `setup.py` to actually point to this repo rather than the one it's forked from, after realizing that this is the one actually on PyPI at the moment  :)