### PR TITLE
Removes Unittest 002

### DIFF
--- a/test.atom
+++ b/test.atom
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<feed xml:lang="en" xmlns="http://www.w3.org/2005/Atom"><title>Poynter E-Media Tidbits</title><link href="http://www.poynter.org/column.asp?id=31" rel="alternate"></link><id>http://www.poynter.org/column.asp?id=31</id><updated>2014-01-07T18:13:47Z</updated><entry><title>Hello</title><link href="http://www.holovaty.com/test/" rel="alternate"></link><id>tag:www.holovaty.com:/test//</id><summary type="html">Testing.</summary></entry></feed>

--- a/test.rss
+++ b/test.rss
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rss version="2.0"><channel><title>Poynter E-Media Tidbits</title><link>http://www.poynter.org/column.asp?id=31</link><description>A group Weblog by the sharpest minds in online media/journalism/publishing.
-    Umlauts: äöüßÄÖÜ
-    Chinese: 老师是四十四，是不是？
-    Finnish: Mustan kissan paksut posket. (ah, no special chars) Kärpänen sanoi kärpäselle: tuu kattoon kattoon ku kaveri tapettiin tapettiin.
-    </description><language>en</language><lastBuildDate>Sun, 26 Aug 2012 07:44:28 -0000</lastBuildDate><item><title>Hello</title><link>http://www.holovaty.com/test/</link><description>Testing.</description></item></channel></rss>

--- a/tests_feedgenerator/test_feedgenerator.py
+++ b/tests_feedgenerator/test_feedgenerator.py
@@ -97,15 +97,7 @@ class TestFeedGenerator(unittest.TestCase):
         self.assertEqual(type(result), type(expected_result))
         self.assertEqual(result, expected_result)
 
-    def OFF_test_002_file_results(self):
-        pass
-        # DO-IT_YOURSELF: Run usage_example with python2 and python3.
-        #                 Each will create a feed file.
-        #                 Compare the files, they must be equal!
-        #                 XXX  Argh -- No, the lastBuildDate will differ.
-        #                              But this is allowed.
-
-    def test_003_string_results_atom(self):
+    def test_002_string_results_atom(self):
         #import ipdb; ipdb.set_trace()
         feed = feedgenerator.Atom1Feed(**FIXT_FEED)
         feed.add_item(**FIXT_ITEM)


### PR DESCRIPTION
- Is a manual test
- Does not increase coverage:
  002 tests the function `feed.write` which gets already tested via `feed.writeString` in the other unit tests.

Fixes #5