### PR TITLE
add image to rss feeds

### DIFF
--- a/feedgenerator/django/utils/feedgenerator.py
+++ b/feedgenerator/django/utils/feedgenerator.py
@@ -89,7 +89,7 @@ class SyndicationFeed(object):
     "Base class for all syndication feeds. Subclasses should provide write()"
     def __init__(self, title, link, description, language=None, author_email=None,
             author_name=None, author_link=None, subtitle=None, categories=None,
-            feed_url=None, feed_copyright=None, feed_guid=None, ttl=None, **kwargs):
+            feed_url=None, feed_copyright=None, image=None, feed_guid=None, ttl=None, **kwargs):
         to_unicode = lambda s: force_text(s, strings_only=True)
         if categories:
             categories = [force_text(c) for c in categories]
@@ -108,6 +108,7 @@ class SyndicationFeed(object):
             'categories': categories or (),
             'feed_url': iri_to_uri(feed_url),
             'feed_copyright': to_unicode(feed_copyright),
+            'image': iri_to_uri(image),
             'id': feed_guid or link,
             'ttl': ttl,
         }
@@ -238,6 +239,12 @@ class RssFeed(SyndicationFeed):
         # Required Elements as per the specification
         handler.addQuickElement("title", self.feed['title'])
         handler.addQuickElement("link", self.feed['link'])
+        if self.feed['image'] is not None:
+            handler.startElement(u'image', {})
+            handler.addQuickElement(u"url", self.feed['link']+self.feed['image'])
+            handler.addQuickElement(u"title", self.feed['title'])
+            handler.addQuickElement(u"link", self.feed['link'])
+            handler.endElement(u'image')
         handler.addQuickElement("description", self.feed['description'])
 
         # Optional Channel Elements


### PR DESCRIPTION
This is a rebased version of https://github.com/dmdm/feedgenerator-py3k/pull/8

At the moment i just concatenate the feedurl with what's in "image" w/o checking if "image" is already a full url - possibly hosted somewhere else.

(Taken from http://stackoverflow.com/questions/660836/django-way-of-specifying-channel-image-in-rss-feed)