### PR TITLE
Replace non-ASCII character in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ FeedGenerator
     :target: https://pypi.org/project/feedgenerator/
     :alt: PyPI Version
 
-FeedGenerator is a standalone version of Django’s feedgenerator_ module.
+FeedGenerator is a standalone version of Django's feedgenerator_ module.
 It has evolved over time and includes numerous enhancements.
 
 .. _feedgenerator: https://github.com/django/django/blob/master/django/utils/feedgenerator.py


### PR DESCRIPTION
This patch enables running setup.py in environments in which `locale.getpreferredencoding(False)` returns `'ASCII'` or any ASCII-compatible encoding.

Fixes #19