### PR TITLE
Install project & dependencies in CI; also test on Python 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Upgrade Pip
         run: python -m pip install -U pip
       - name: Install package and dependencies
-        run: pip install -e .
+        run: python -m pip install -e .
       - name: Test with pytest
         run: |
           python -m pip install pytest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Upgrade Pip
         run: python -m pip install -U pip
       - name: Install package and dependencies
-        run: python setup.py -e .
+        run: pip install -e .
       - name: Test with pytest
         run: |
           python -m pip install pytest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2
@@ -21,6 +21,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Upgrade Pip
         run: python -m pip install -U pip
+      - name: Install package and dependencies
+        run: python setup.py -e .
       - name: Test with pytest
         run: |
           python -m pip install pytest


### PR DESCRIPTION
The test pipelines are failing because the requirements are missing. This can be simply fixed by running `pip install -e .` before running the tests.

This MR also adds Python3.9