### PR TITLE
Fix setup.py warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [sdist]
-force-manifest = 1
+force_manifest = 1


### PR DESCRIPTION
Fix the following warning:

    /usr/lib/python3.10/site-packages/setuptools/dist.py:691: UserWarning: Usage of dash-separated 'force-manifest' will not be supported in future versions. Please use the underscore name 'force_manifest' instead