### PR TITLE
Add test coverage report

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,5 +25,5 @@ jobs:
         run: python -m pip install -e .
       - name: Test with pytest
         run: |
-          python -m pip install pytest
+          python -m pip install pytest pytest-cov
           pytest

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ pip-log.txt
 # Unit test / coverage reports
 .coverage
 .tox
+htmlcov/
 
 #Translations
 *.mo

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,9 @@
 [sdist]
 force_manifest = 1
+
+[tool:pytest]
+addopts =
+    --cov=feedgenerator
+    --cov=tests_feedgenerator
+    --cov-report=html
+    --cov-report=term-missing:skip-covered

--- a/tox.ini
+++ b/tox.ini
@@ -12,3 +12,4 @@ commands =
     pytest
 deps =
     pytest
+    pytest-cov


### PR DESCRIPTION
this change should be useful for bigger migrations like the py2-removal.

this config will omit the report on files with 100% coverage