### PR TITLE
Exclude tests_feedgenerator/__pycache__ from distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.rst LICENSE tox.ini
 recursive-include tests_feedgenerator *
+exclude tests_feedgenerator/__pycache__/*


### PR DESCRIPTION
The `__pycache__` directory is created when tests are run, but should not be distributed.