### PR TITLE
This adds a non-ASCII charachter into the test case to cover if we

### DIFF
--- a/tests/test_feedgenerator.py
+++ b/tests/test_feedgenerator.py
@@ -17,7 +17,7 @@ FIXT_FEED = dict(
 )
 FIXT_ITEM = dict(
     title="Hello",
-    link="http://www.holovaty.com/test/",
+    link="http://www.holovaty.com/täst/",
     description="Testing.",
     content="Full content of our testing entry.",
     pubdate=datetime.datetime(2016,8,11,0,0,0,0),
@@ -29,14 +29,14 @@ EXPECTED_RESULT_RSS = """<?xml version="1.0" encoding="utf-8"?>
     Umlauts: äöüßÄÖÜ
     Chinese: 老师是四十四，是不是？
     Finnish: Mustan kissan paksut posket. (ah, no special chars) Kärpänen sanoi kärpäselle: tuu kattoon kattoon ku kaveri tapettiin tapettiin.
-    </description><language>en</language><lastBuildDate>%DATE%</lastBuildDate><item><title>Hello</title><link>http://www.holovaty.com/test/</link><description>Testing.</description><pubDate>Thu, 11 Aug 2016 00:00:00 -0000</pubDate></item></channel></rss>"""
+    </description><language>en</language><lastBuildDate>%DATE%</lastBuildDate><item><title>Hello</title><link>http://www.holovaty.com/t%C3%A4st/</link><description>Testing.</description><pubDate>Thu, 11 Aug 2016 00:00:00 -0000</pubDate></item></channel></rss>"""
 
 EXPECTED_RESULT_ATOM = """<?xml version="1.0" encoding="utf-8"?>
 <feed xml:lang="en" xmlns="http://www.w3.org/2005/Atom"><title>Poynter E-Media Tidbits</title><link href="http://www.poynter.org/column.asp?id=31" rel="alternate"></link><id>http://www.poynter.org/column.asp?id=31</id><updated>%DATE%</updated><subtitle>A group Weblog by the sharpest minds in online media/journalism/publishing.
     Umlauts: äöüßÄÖÜ
     Chinese: 老师是四十四，是不是？
     Finnish: Mustan kissan paksut posket. (ah, no special chars) Kärpänen sanoi kärpäselle: tuu kattoon kattoon ku kaveri tapettiin tapettiin.
-    </subtitle><entry><title>Hello</title><link href="http://www.holovaty.com/test/" rel="alternate"></link><published>2016-08-11T00:00:00Z</published><updated>2016-08-11T00:00:00Z</updated><id>tag:www.holovaty.com,2016-08-11:/test/</id><summary type="html">Testing.</summary><content type="html">Full content of our testing entry.</content></entry></feed>"""
+    </subtitle><entry><title>Hello</title><link href="http://www.holovaty.com/t%C3%A4st/" rel="alternate"></link><published>2016-08-11T00:00:00Z</published><updated>2016-08-11T00:00:00Z</updated><id>tag:www.holovaty.com,2016-08-11:/t%C3%A4st/</id><summary type="html">Testing.</summary><content type="html">Full content of our testing entry.</content></entry></feed>"""
 
 ENCODING = 'utf-8'
 


### PR DESCRIPTION
convert properly using percent-encoding.

Apparently we do, so no other change is needed. Closes: #21