### PR TITLE
Add python 3 13 support and test with uv

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,21 +15,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+    env:
+      UV_PYTHON: ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Upgrade Pip
-        run: python -m pip install -U pip
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
       - name: Install package and development dependencies
-        run: python -m pip install -e .[dev]
+        run: uv sync --all-extras --dev
       - name: Test with pytest
         run: |
-          pytest
+          uv run pytest
 
   deploy:
     name: Deploy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     "Topic :: Software Development :: Libraries :: Python Modules",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{3.8,3.9,3.10,3.11,3.12}
+envlist = py{3.8,3.9,3.10,3.11,3.12,3.13}
 
 [testenv]
 basepython =
@@ -8,6 +8,7 @@ basepython =
     py3.10: python3.10
     py3.11: python3.11
     py3.12: python3.12
+    py3.13: python3.13
 commands =
     {envpython} --version
     pytest


### PR DESCRIPTION
This change adds:

* Python 3.13 test workflow
* Python 3.13 environment in tox
* Change to uv for initializing environment
* Add classifiers in pyproject.toml

As a side note, locally I tested using uv and [tox-uv](https://pypi.org/project/tox-uv/), if tox adds any value perhaps we should use it in the Github workflows